### PR TITLE
Return if cookie session cannot be found inside system sessions table to avoid unnecessary userdata and settings assignment

### DIFF
--- a/php/Database/Session.php
+++ b/php/Database/Session.php
@@ -21,6 +21,7 @@ namespace Database {
                     $userid = $userid[0]["User_ID"];
                 } else {
                     setcookie("session", "", -1);
+                    return;
                 }
 
                 $this->userdata = Data\OsekaiUsers::GetUser($userid, true);


### PR DESCRIPTION
## What this MR fixes

This MR fixes invalid session handling in `php/Database/Session.php`.

## Problem

In `php/Database/Session.php:19`, the code queries `System_Sessions` by cookie key.

When no row is found, the code clears the cookie at `php/Database/Session.php:23`:

```php
setcookie("session", "", -1);
```

## Why this is a bug

After clearing the cookie, the constructor still continued to:

- `php/Database/Session.php:26` (`$this->userdata = Data\OsekaiUsers::GetUser($userid, true);`)
- `php/Database/Session.php:27` (`$this->settings = Data\Settings::Get($userid);`)

At that point, `$userid` can still be the empty query result (`[]`).

That value then flows into `php/Data/OsekaiUsers.php:11`, and eventually into the osu! API URL in `php/API/Osu/User.php:13`:

```php
curl_setopt($handle, CURLOPT_URL, "https://osu.ppy.sh/api/v2/users/" . $id . "/" . $gamemode);
```
This can lead to requests using an invalid user identifier (in this case: `api/v2/users/Array`), likely due to array-to-string handling of `$userid` somewhere in that flow.

Impact: an invalid session can result in authentication as the user `Array`.

Attached is a video demonstrating the behavior.

https://github.com/user-attachments/assets/57441457-ff88-4a53-ad81-0ec5d5fb6ab7


## Change implemented

Added an early return at `php/Database/Session.php:24`:

```php
return;
```

For invalid session keys, the code now clears the cookie and stops session initialization immediately.
