### PR TITLE
fix: country search now accepts full names and 2-letter codes

### DIFF
--- a/php/Data/Rankings.php
+++ b/php/Data/Rankings.php
@@ -165,6 +165,10 @@ ORDER BY Rankings_Users.Count_Medals DESC";
                 $searchWhereClause = "WHERE $searchColumn = ?";
                 $searchParams[] = $searchQuery;
                 $searchTypes .= is_numeric($searchQuery) ? "i" : "s";
+            } else if ($searchColumn === "Country_Code") {
+                $searchWhereClause = "WHERE UPPER(Country_Code) = UPPER(?) OR Country_Code IN (SELECT Country_Code FROM Common_Countries WHERE Name LIKE ?)";
+                array_push($searchParams, $searchQuery, "$searchQuery%");
+                $searchTypes .= "ss";
             } else {
                 $searchWhereClause = "WHERE $searchColumn LIKE ?";
                 $searchParams[] = "%$searchQuery%";


### PR DESCRIPTION
## Problem
Country search only accepted 2-letter codes (e.g. `TH`).
Searching by full name (e.g. `Thailand`) returned no results.

## Fix
Added a lookup against `Common_Countries.Name` so both `TH` and `Thailand` now work.


Video attached showing before/after behavior.

https://github.com/user-attachments/assets/5eb67333-7f7b-4417-a0a0-2d11922975d5




