### PR TITLE
Fix/home bg animation resize on restore

### DIFF
--- a/frontend/src/js/views/home.js
+++ b/frontend/src/js/views/home.js
@@ -2,91 +2,40 @@ import "../../css/views/home.css";
 import * as UnicornStudio from '../external/unicornStudio.umd.js'
 import lottie from "lottie-web";
 
-var sceneConfig = {
+var conf = {
     elementId: "unicorn",
     fps: 40,
-    scale: window.innerWidth < 600 ? 0.5 : 0.6,
+    scale: 0.6,
     dpi: 1.5,
     filePath: "/public/inex.json",
     fixed: true
 };
+if (window.innerWidth < 600) {
+    conf.scale = 0.5;
+}
 
-let activeUnicornScene = null;
-
-UnicornStudio.addScene(sceneConfig)
+UnicornStudio.addScene(conf)
     .then((scene) => {
-        activeUnicornScene = scene;
         document.body.classList.add("loaded");
-
-        const canvas = document.querySelector("#unicorn canvas");
-        if (canvas && typeof ResizeObserver !== "undefined") {
-            new ResizeObserver(() => {
-                if (canvas.offsetWidth > 0 && canvas.offsetHeight > 0) {
-                    remeasureUnicornCanvasToViewport();
-                }
-            }).observe(canvas);
-        }
+        const el = document.getElementById("unicorn");
+        window.addEventListener("resize", () => {
+            if (!scene?.resize) return;
+            if (el) {
+                el.style.width = window.innerWidth + "px";
+                el.style.height = window.innerHeight + "px";
+                el.getBoundingClientRect(); // force reflow
+            }
+            scene.resize();
+            scene.requestSceneRender?.();
+            if (el) { el.style.width = ""; el.style.height = ""; }
+        });
     })
     .catch((err) => {
         console.error(err);
         document.body.classList.add("loaded");
     });
 
-function remeasureUnicornCanvasToViewport() {
-    if (!activeUnicornScene?.resize) return;
-
-    const unicornContainer = document.getElementById("unicorn");
-    if (unicornContainer) {
-        unicornContainer.style.width = window.innerWidth + "px";
-        unicornContainer.style.height = window.innerHeight + "px";
-        unicornContainer.getBoundingClientRect(); // force reflow
-    }
-
-    let resizeOk = false;
-    try {
-        activeUnicornScene.resize();
-        resizeOk = true;
-    } catch (err) {
-        console.error("[unicorn] resize() threw", err);
-    }
-
-    if (resizeOk && typeof activeUnicornScene.renderFrame === "function") {
-        try {
-            activeUnicornScene.renderFrame();
-        } catch (err) {
-            console.error("[unicorn] renderFrame() threw", err);
-        }
-    }
-
-    if (unicornContainer) {
-        unicornContainer.style.width = "";
-        unicornContainer.style.height = "";
-    }
-}
-
-
-function scheduleUnicornRefresh() {
-    remeasureUnicornCanvasToViewport();
-    requestAnimationFrame(remeasureUnicornCanvasToViewport);
-    requestAnimationFrame(() => requestAnimationFrame(remeasureUnicornCanvasToViewport));
-    /*setTimeout(remeasureUnicornCanvasToViewport, 200);
-    setTimeout(remeasureUnicornCanvasToViewport, 500);
-    setTimeout(remeasureUnicornCanvasToViewport, 1000);*/
-}
-
-window.addEventListener("focus", scheduleUnicornRefresh);
-document.addEventListener("visibilitychange", () => {
-    if (document.visibilityState === "visible") scheduleUnicornRefresh();
-});
-window.addEventListener("pageshow", scheduleUnicornRefresh);
-window.addEventListener("resize", scheduleUnicornRefresh);
-
-const unicornContainer = document.getElementById("unicorn");
-if (unicornContainer && typeof ResizeObserver !== "undefined") {
-    new ResizeObserver(remeasureUnicornCanvasToViewport).observe(unicornContainer);
-}
-
-const homePageAnimation = lottie.loadAnimation({
+const anim = lottie.loadAnimation({
     container: document.getElementById("logo-anim"),
     renderer: "svg",
     autoplay: false,
@@ -94,16 +43,14 @@ const homePageAnimation = lottie.loadAnimation({
     path: "/public/osekai-lottie.json",
 });
 
-homePageAnimation.addEventListener("config_ready", () => {
-    homePageAnimation.setSpeed(0.8);
-    homePageAnimation.play();
+anim.addEventListener("config_ready", () => {
+    anim.setSpeed(0.8);
+    anim.play();
     document.getElementById("home-welcome").classList.add("lottie-running");
     setTimeout(() => {
         document.getElementById("home-welcome").classList.add("lottie-done");
-    }, 700);
+    }, 700)
     setTimeout(() => {
         document.getElementById("home-welcome").classList.add("lottie-doner");
-    }, 2100);
-});
-
-
+    }, 2100)
+})

--- a/frontend/src/js/views/home.js
+++ b/frontend/src/js/views/home.js
@@ -2,19 +2,20 @@ import "../../css/views/home.css";
 import * as UnicornStudio from '../external/unicornStudio.umd.js'
 import lottie from "lottie-web";
 
-var conf = {
+var sceneConfig = {
     elementId: "unicorn",
     fps: 40,
-    scale: 0.6,
+    scale: window.innerWidth < 600 ? 0.5 : 0.6,
     dpi: 1.5,
     filePath: "/public/inex.json",
     fixed: true
 };
-if (window.innerWidth < 600) {
-    conf.scale = 0.5;
-}
-UnicornStudio.addScene(conf)
+
+let activeUnicornScene = null;
+
+UnicornStudio.addScene(sceneConfig)
     .then((scene) => {
+        activeUnicornScene = scene;
         document.body.classList.add("loaded");
     })
     .catch((err) => {
@@ -22,22 +23,58 @@ UnicornStudio.addScene(conf)
         document.body.classList.add("loaded");
     });
 
+function remeasureUnicornCanvasToViewport() {
+    if (!activeUnicornScene?.resize) return;
 
-const anim = lottie.loadAnimation({
+    const unicornContainer = document.getElementById("unicorn");
+    if (unicornContainer) {
+        unicornContainer.style.width = window.innerWidth + "px";
+        unicornContainer.style.height = window.innerHeight + "px";
+    }
+    try {
+        activeUnicornScene.resize();
+    } catch (err) {
+        console.error("[unicorn] resize failed", err);
+    }
+    if (unicornContainer) {
+        unicornContainer.style.width = "";
+        unicornContainer.style.height = "";
+    }
+}
+
+function scheduleUnicornRemeasureAcrossFrames() {
+    requestAnimationFrame(remeasureUnicornCanvasToViewport);
+    requestAnimationFrame(() => requestAnimationFrame(remeasureUnicornCanvasToViewport));
+    setTimeout(remeasureUnicornCanvasToViewport, 200);
+}
+
+window.addEventListener("focus", scheduleUnicornRemeasureAcrossFrames);
+document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "visible") scheduleUnicornRemeasureAcrossFrames();
+});
+window.addEventListener("pageshow", scheduleUnicornRemeasureAcrossFrames);
+
+const unicornContainer = document.getElementById("unicorn");
+if (unicornContainer && typeof ResizeObserver !== "undefined") {
+    new ResizeObserver(remeasureUnicornCanvasToViewport).observe(unicornContainer);
+}
+
+const logoAnimation = lottie.loadAnimation({
     container: document.getElementById("logo-anim"),
     renderer: "svg",
     autoplay: false,
     loop: false,
     path: "/public/osekai-lottie.json",
 });
-anim.addEventListener("config_ready", () => {
-    anim.setSpeed(0.8);
-    anim.play();
+
+logoAnimation.addEventListener("config_ready", () => {
+    logoAnimation.setSpeed(0.8);
+    logoAnimation.play();
     document.getElementById("home-welcome").classList.add("lottie-running");
     setTimeout(() => {
         document.getElementById("home-welcome").classList.add("lottie-done");
-    }, 700)
+    }, 700);
     setTimeout(() => {
         document.getElementById("home-welcome").classList.add("lottie-doner");
-    }, 2100)
-})
+    }, 2100);
+});

--- a/frontend/src/js/views/home.js
+++ b/frontend/src/js/views/home.js
@@ -17,6 +17,15 @@ UnicornStudio.addScene(sceneConfig)
     .then((scene) => {
         activeUnicornScene = scene;
         document.body.classList.add("loaded");
+
+        const canvas = document.querySelector("#unicorn canvas");
+        if (canvas && typeof ResizeObserver !== "undefined") {
+            new ResizeObserver(() => {
+                if (canvas.offsetWidth > 0 && canvas.offsetHeight > 0) {
+                    remeasureUnicornCanvasToViewport();
+                }
+            }).observe(canvas);
+        }
     })
     .catch((err) => {
         console.error(err);
@@ -30,22 +39,39 @@ function remeasureUnicornCanvasToViewport() {
     if (unicornContainer) {
         unicornContainer.style.width = window.innerWidth + "px";
         unicornContainer.style.height = window.innerHeight + "px";
+        unicornContainer.getBoundingClientRect(); // force reflow
     }
+
+    let resizeOk = false;
     try {
         activeUnicornScene.resize();
+        resizeOk = true;
     } catch (err) {
-        console.error("[unicorn] resize failed", err);
+        console.error("[unicorn] resize() threw", err);
     }
+
+    if (resizeOk && typeof activeUnicornScene.renderFrame === "function") {
+        try {
+            activeUnicornScene.renderFrame();
+        } catch (err) {
+            console.error("[unicorn] renderFrame() threw", err);
+        }
+    }
+
     if (unicornContainer) {
         unicornContainer.style.width = "";
         unicornContainer.style.height = "";
     }
 }
 
+
 function scheduleUnicornRefresh() {
+    remeasureUnicornCanvasToViewport();
     requestAnimationFrame(remeasureUnicornCanvasToViewport);
     requestAnimationFrame(() => requestAnimationFrame(remeasureUnicornCanvasToViewport));
-    setTimeout(remeasureUnicornCanvasToViewport, 200);
+    /*setTimeout(remeasureUnicornCanvasToViewport, 200);
+    setTimeout(remeasureUnicornCanvasToViewport, 500);
+    setTimeout(remeasureUnicornCanvasToViewport, 1000);*/
 }
 
 window.addEventListener("focus", scheduleUnicornRefresh);
@@ -53,6 +79,7 @@ document.addEventListener("visibilitychange", () => {
     if (document.visibilityState === "visible") scheduleUnicornRefresh();
 });
 window.addEventListener("pageshow", scheduleUnicornRefresh);
+window.addEventListener("resize", scheduleUnicornRefresh);
 
 const unicornContainer = document.getElementById("unicorn");
 if (unicornContainer && typeof ResizeObserver !== "undefined") {
@@ -78,3 +105,5 @@ homePageAnimation.addEventListener("config_ready", () => {
         document.getElementById("home-welcome").classList.add("lottie-doner");
     }, 2100);
 });
+
+

--- a/frontend/src/js/views/home.js
+++ b/frontend/src/js/views/home.js
@@ -42,24 +42,24 @@ function remeasureUnicornCanvasToViewport() {
     }
 }
 
-function scheduleUnicornRemeasureAcrossFrames() {
+function scheduleUnicornRefresh() {
     requestAnimationFrame(remeasureUnicornCanvasToViewport);
     requestAnimationFrame(() => requestAnimationFrame(remeasureUnicornCanvasToViewport));
     setTimeout(remeasureUnicornCanvasToViewport, 200);
 }
 
-window.addEventListener("focus", scheduleUnicornRemeasureAcrossFrames);
+window.addEventListener("focus", scheduleUnicornRefresh);
 document.addEventListener("visibilitychange", () => {
-    if (document.visibilityState === "visible") scheduleUnicornRemeasureAcrossFrames();
+    if (document.visibilityState === "visible") scheduleUnicornRefresh();
 });
-window.addEventListener("pageshow", scheduleUnicornRemeasureAcrossFrames);
+window.addEventListener("pageshow", scheduleUnicornRefresh);
 
 const unicornContainer = document.getElementById("unicorn");
 if (unicornContainer && typeof ResizeObserver !== "undefined") {
     new ResizeObserver(remeasureUnicornCanvasToViewport).observe(unicornContainer);
 }
 
-const logoAnimation = lottie.loadAnimation({
+const homePageAnimation = lottie.loadAnimation({
     container: document.getElementById("logo-anim"),
     renderer: "svg",
     autoplay: false,
@@ -67,9 +67,9 @@ const logoAnimation = lottie.loadAnimation({
     path: "/public/osekai-lottie.json",
 });
 
-logoAnimation.addEventListener("config_ready", () => {
-    logoAnimation.setSpeed(0.8);
-    logoAnimation.play();
+homePageAnimation.addEventListener("config_ready", () => {
+    homePageAnimation.setSpeed(0.8);
+    homePageAnimation.play();
     document.getElementById("home-welcome").classList.add("lottie-running");
     setTimeout(() => {
         document.getElementById("home-welcome").classList.add("lottie-done");

--- a/frontend/src/js/views/home.js
+++ b/frontend/src/js/views/home.js
@@ -19,15 +19,9 @@ UnicornStudio.addScene(conf)
         document.body.classList.add("loaded");
         const el = document.getElementById("unicorn");
         window.addEventListener("resize", () => {
-            if (!scene?.resize) return;
-            if (el) {
-                el.style.width = window.innerWidth + "px";
-                el.style.height = window.innerHeight + "px";
-                el.getBoundingClientRect(); // force reflow
-            }
+            el.style.width = window.innerWidth + "px";
             scene.resize();
             scene.requestSceneRender?.();
-            if (el) { el.style.width = ""; el.style.height = ""; }
         });
     })
     .catch((err) => {


### PR DESCRIPTION
Fixes #67

Set container width to viewport width before `scene.resize()` so the library reads the correct dimensions, then `requestSceneRender()` to repaint without flicker.