### PR TITLE
fix: change .rawtext to .value

### DIFF
--- a/frontend/src/js/views/medals/ui/MedalsSidebar.js
+++ b/frontend/src/js/views/medals/ui/MedalsSidebar.js
@@ -19,7 +19,7 @@ export class MedalsSidebar {
 
     Search(rawtext = null) {
         if (rawtext == null) {
-            rawtext = document.getElementById("medal_search").rawtext;
+            rawtext = document.getElementById("medal_search").value;
         }
         if (rawtext.length > 0) {
             document.getElementById("medal_search_clear").classList.remove("hidden");


### PR DESCRIPTION
Stops Search() from erroring due to undefined rawtext (when called from changing "Completely hide obtained medals" setting).
This might resolve #63.

Edit: Force-pushed to get rid of stray newline change. (Where did that come from…)